### PR TITLE
Update docker-compose-artifact-registry.yml

### DIFF
--- a/docker-compose-artifact-registry.yml
+++ b/docker-compose-artifact-registry.yml
@@ -1,6 +1,6 @@
 services:
   cdp:
-    image: cdp:latest
+    image: cdp:${CDP_TAG}
     container_name: cdp
     ports:
       - 5003:5003


### PR DESCRIPTION
Add tag to container when deploying so we know what version we are working with. 
 Was "latest" which wasn't very useful.
 
new-deployment job does not work without this change.